### PR TITLE
Cocoapods

### DIFF
--- a/GeoFire.podspec
+++ b/GeoFire.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.docset_url   = "https://geofire-ios.firebaseapp.com/docs/"
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.8'
-  s.dependency  'Firebase'
+  s.dependency  'Firebase', '~> 1.2'
   s.framework = 'CoreLocation'
   s.xcconfig     = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/Firebase"'}
 end


### PR DESCRIPTION
@vikrum Here's a working podspec for geofire-objc.  I modeled it after the podspec in firebase-client-objc.  Does geofire-objc need all the release logic in firebase-client-objc/release.sh?  I figured since this library is open sourced, and much less updated, it wouldn't be too hard to just bump the version number in the podspec and do a `pod trunk` every once in awhile.
