### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pod 'GeoFire', '>= 1.1'
 
 ### Using GeoFire with Swift
 
-GeoFire supports Swift out of the box! In order to use GeoFire and Swift from Cocoapods, add the `use_frameworks!` line to your `Podfile`, like so:
+GeoFire supports Swift out of the box! In order to use GeoFire and Swift from CocoaPods, add the `use_frameworks!` line to your `Podfile`, like so:
 
 ````
 use_frameworks!
@@ -305,7 +305,7 @@ events might occur independently.
 - `git pull` to update the master branch
 - tag and push the tag for this release
 - `./build.sh` to build a binary
-- From your macbook that already has been granted permissions to Firebase Cocoapods, do `pod trunk push`
+- From your macbook that already has been granted permissions to Firebase CocoaPods, do `pod trunk push`
 - Update [firebase-versions](https://github.com/firebase/firebase-clients/blob/master/versions/firebase-versions.json) with the changelog for this release.
 - Add the compiled `target/GeoFire.framework.zip` to the release
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
