### PR TITLE
Implements basic all keys changed block.

### DIFF
--- a/GeoFire/API/GFQuery.h
+++ b/GeoFire/API/GFQuery.h
@@ -40,6 +40,7 @@ typedef NS_ENUM(NSUInteger, GFEventType) {
 };
 
 typedef void (^GFQueryResultBlock) (NSString *key, CLLocation *location);
+typedef void (^GFQueryKeysBlock) (NSDictionary *keysAndLocations);
 typedef void (^GFReadyBlock) ();
 
 /**
@@ -75,6 +76,16 @@ typedef void (^GFReadyBlock) ();
 */
 
 - (FirebaseHandle)observeEventType:(GFEventType)eventType withBlock:(GFQueryResultBlock)block;
+
+/**
+ * Adds an observer that is called once all initial GeoFire data has been loaded and the relevant events have
+ * been fired for this query. Every time the query criteria is updated, this observer will be called after the
+ * updated query has fired the appropriate key entered or key exited events.
+ *
+ * @param block The block that is called for the keys changed event
+ * @return A handle to remove the observer with
+ */
+- (FirebaseHandle)observeKeysChangedWithBlock:(GFQueryKeysBlock)block;
 
 /**
  * Adds an observer that is called once all initial GeoFire data has been loaded and the relevant events have

--- a/GeoFire/Implementation/GFQuery.m
+++ b/GeoFire/Implementation/GFQuery.m
@@ -177,6 +177,7 @@
 @property (nonatomic, strong) NSMutableDictionary *keyEnteredObservers;
 @property (nonatomic, strong) NSMutableDictionary *keyExitedObservers;
 @property (nonatomic, strong) NSMutableDictionary *keyMovedObservers;
+@property (nonatomic, strong) NSMutableDictionary *keysChangedObservers;
 @property (nonatomic, strong) NSMutableDictionary *readyObservers;
 @property (nonatomic) NSUInteger currentHandle;
 
@@ -336,6 +337,13 @@
 - (void)checkAndFireReadyEvent
 {
     if (self.outstandingQueries.count == 0) {
+        
+        [self.keysChangedObservers enumerateKeysAndObjectsUsingBlock:^(id  key, GFQueryKeysBlock block, BOOL * stop) {
+            dispatch_async(self.geoFire.callbackQueue, ^{
+                block(locationInfos);
+            });
+        }]
+        
         [self.readyObservers enumerateKeysAndObjectsUsingBlock:^(id key, GFReadyBlock block, BOOL *stop) {
             dispatch_async(self.geoFire.callbackQueue, block);
         }];
@@ -422,6 +430,7 @@
     self.keyEnteredObservers = [NSMutableDictionary dictionary];
     self.keyExitedObservers = [NSMutableDictionary dictionary];
     self.keyMovedObservers = [NSMutableDictionary dictionary];
+    self.keysChangedObservers = [NSMutableDictionary dictionary];
     self.readyObservers = [NSMutableDictionary dictionary];
     self.locationInfos = [NSMutableDictionary dictionary];
 }
@@ -440,6 +449,7 @@
         [self.keyEnteredObservers removeObjectForKey:handle];
         [self.keyExitedObservers removeObjectForKey:handle];
         [self.keyMovedObservers removeObjectForKey:handle];
+        [self.keysChangedObservers removeObjectForKey:handle];
         [self.readyObservers removeObjectForKey:handle];
         if ([self totalObserverCount] == 0) {
             [self reset];
@@ -500,6 +510,27 @@
         }
         if (self.queries == nil) {
             [self updateQueries];
+        }
+        return firebaseHandle;
+    }
+}
+
+- (FirebaseHandle)observeKeysChangedWithBlock:(GFQueryKeysBlock)block
+{
+    @synchronized(self) {
+        if (block == nil) {
+            [NSException raise:NSInvalidArgumentException format:@"Block is not allowed to be nil!"];
+        }
+        FirebaseHandle firebaseHandle = self.currentHandle++;
+        NSNumber *numberHandle = [NSNumber numberWithUnsignedInteger:firebaseHandle];
+        [self.keysChangedObservers setObject:[block copy] forKey:numberHandle];
+        if (self.queries == nil) {
+            [self updateQueries];
+        }
+        if (self.outstandingQueries.count == 0) {
+            dispatch_async(self.geoFire.callbackQueue, ^{
+                block(locationInfos);
+            });
         }
         return firebaseHandle;
     }


### PR DESCRIPTION
This introduces a new callback for when the nearby keys have changes, this is useful when you just want to reload your entire interface with the nearby keys.

As it is simpler than having to collect the insert and delete events followed by waiting for the ready event.
