### PR TITLE
Use #import instead of @import

### DIFF
--- a/GeoFire.podspec
+++ b/GeoFire.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source_files = "GeoFire/**/*.{h,m}"
   s.documentation_url   = "https://geofire-ios.firebaseapp.com/docs/"
   s.ios.deployment_target = '7.0'
-  s.ios.dependency  'Firebase', '~> 3.2'
+  s.ios.dependency  'Firebase/Database', '~> 3.2'
   s.framework = 'CoreLocation'
   s.requires_arc = true
 end

--- a/GeoFire/Implementation/GFQuery.m
+++ b/GeoFire/Implementation/GFQuery.m
@@ -6,6 +6,8 @@
 //  Copyright (c) 2014 Firebase. All rights reserved.
 //
 
+#import <FirebaseDatabase/FirebaseDatabase.h>
+
 #import "GFQuery.h"
 #import "GFRegionQuery.h"
 #import "GFCircleQuery.h"
@@ -13,7 +15,6 @@
 #import "GeoFire.h"
 #import "GeoFire+Private.h"
 #import "GFGeoHashQuery.h"
-@import FirebaseDatabase;
 
 @interface GFQueryLocationInfo : NSObject
 

--- a/GeoFire/Implementation/GeoFire.m
+++ b/GeoFire/Implementation/GeoFire.m
@@ -6,11 +6,12 @@
 //  Copyright (c) 2014 Firebase. All rights reserved.
 //
 
+#import <FirebaseDatabase/FirebaseDatabase.h>
+
 #import "GeoFire.h"
 #import "GeoFire+Private.h"
 #import "GFGeoHash.h"
 #import "GFQuery+Private.h"
-@import FirebaseDatabase;
 
 NSString * const kGeoFireErrorDomain = @"com.firebase.geofire";
 


### PR DESCRIPTION
It seems like CocoaPods does not support module imports for Pod dependencies. This changes it back to traditional imports and updates the Firebase dependency to include only the Database.