### PR TITLE
Added optional CLLocation properties

### DIFF
--- a/GeoFire/API/GeoFire.h
+++ b/GeoFire/API/GeoFire.h
@@ -73,7 +73,7 @@ typedef void (^GFCallbackBlock) (CLLocation *location, NSError *error);
 /**
  * Initializes a new GeoFire instance at the given Firebase location.
  * @param firebase The Firebase location to attach this GeoFire instance to
- * @param properties Additional CLLocation properties to save and load
+ * @param locationProperties Additional CLLocation properties to save and load
  * @return The new GeoFire instance
  */
 - (id)initWithFirebaseRef:(FIRDatabaseReference *)firebase locationProperties:(CLLocationProperties)locationProperties;
@@ -129,7 +129,6 @@ withCompletionBlock:(GFCompletionBlock)block;
  *
  * @param key The key to observe the location for
  * @param callback The callback that is called for the current location
- * @return
  */
 - (void)getLocationForKey:(NSString *)key
              withCallback:(GFCallbackBlock)callback;

--- a/GeoFire/API/GeoFire.h
+++ b/GeoFire/API/GeoFire.h
@@ -34,6 +34,15 @@
 #import "GFCircleQuery.h"
 #import "GFRegionQuery.h"
 
+typedef enum : NSUInteger {
+	CLLocationPropertyAltitude = 1,
+	CLLocationPropertyHorizontalAccuracy,
+	CLLocationPropertyVerticalAccuracy,
+	CLLocationPropertyCourse,
+	CLLocationPropertySpeed,
+	CLLocationPropertyTimestamp
+} CLLocationProperties;
+
 @class FIRDatabaseReference;
 
 typedef void (^GFCompletionBlock) (NSError *error);
@@ -53,6 +62,21 @@ typedef void (^GFCallbackBlock) (CLLocation *location, NSError *error);
  * The dispatch queue this GeoFire object and all its GFQueries use for callbacks.
  */
 @property (nonatomic, strong) dispatch_queue_t callbackQueue;
+
+/**
+ * Additional CLLocation properties to save and load.
+ */
+@property (nonatomic, assign, readonly) CLLocationProperties locationProperties;
+
+/** @name Creating new GeoFire objects */
+
+/**
+ * Initializes a new GeoFire instance at the given Firebase location.
+ * @param firebase The Firebase location to attach this GeoFire instance to
+ * @param properties Additional CLLocation properties to save and load
+ * @return The new GeoFire instance
+ */
+- (id)initWithFirebaseRef:(FIRDatabaseReference *)firebase locationProperties:(CLLocationProperties)locationProperties;
 
 /** @name Creating new GeoFire objects */
 

--- a/GeoFire/API/GeoFire.h
+++ b/GeoFire/API/GeoFire.h
@@ -35,12 +35,12 @@
 #import "GFRegionQuery.h"
 
 typedef enum : NSUInteger {
-	CLLocationPropertyAltitude = 1,
-	CLLocationPropertyHorizontalAccuracy,
-	CLLocationPropertyVerticalAccuracy,
-	CLLocationPropertyCourse,
-	CLLocationPropertySpeed,
-	CLLocationPropertyTimestamp
+	CLLocationPropertyAltitude				= 1 << 0,
+	CLLocationPropertyHorizontalAccuracy	= 1 << 1,
+	CLLocationPropertyVerticalAccuracy		= 1 << 2,
+	CLLocationPropertyCourse				= 1 << 3,
+	CLLocationPropertySpeed					= 1 << 4,
+	CLLocationPropertyTimestamp				= 1 << 5,
 } CLLocationProperties;
 
 @class FIRDatabaseReference;

--- a/build.sh
+++ b/build.sh
@@ -22,6 +22,8 @@ ${XCODEBUILD} \
   IPHONEOS_DEPLOYMENT_TARGET=7.0 \
   ONLY_ACTIVE_ARCH=NO \
   ARCHS="armv7 armv7s arm64" \
+  ENABLE_BITCODE=YES \
+  BITCODE_GENERATION_MODE=bitcode \
   build
 
 echo "===> Building simulator binary"


### PR DESCRIPTION
Additional properties of CLLocation might be useful in some situations. So I added an optional constructor parameter locationProperties. If it is set to value greater than 0 it will make GeoFire write and read additional properties like altitude and timestamp.