### PR TITLE
Fix of “can't locate file for: -lPods-GeoFire” on ./build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 set -e # Exit sub shell if anything erro
 DIR="$(cd "$(dirname "$0")"; pwd)"
 OUTPUT_DIR="${DIR}/target/"
-XCODE_PROJECT="${DIR}/GeoFire.xcodeproj"
+XCODE_WORKSPACE="${DIR}/GeoFire.xcworkspace"
 XCODEBUILD=xcodebuild
 
 echo "===> Cleaning target directory"
@@ -11,8 +11,8 @@ rm -rf $OUTPUT_DIR
 
 echo "===> Building iOS binary"
 ${XCODEBUILD} \
-  -project ${XCODE_PROJECT} \
-  -target GeoFire \
+  -workspace ${XCODE_WORKSPACE} \
+  -scheme GeoFire \
   -configuration Release \
   -sdk iphoneos \
   BUILD_DIR=${OUTPUT_DIR}/Products \
@@ -26,8 +26,8 @@ ${XCODEBUILD} \
 
 echo "===> Building simulator binary"
 ${XCODEBUILD} \
-  -project ${XCODE_PROJECT} \
-  -target GeoFire \
+  -workspace ${XCODE_WORKSPACE} \
+  -scheme GeoFire \
   -configuration Release \
   -sdk iphonesimulator \
   BUILD_DIR=${OUTPUT_DIR}/Products \


### PR DESCRIPTION
The ./build.sh execution is failed after cloning the project and pod install. This is the fix for that. Thanks.