### PR TITLE
Use FirebaseCommunity pod to resolve "transitive dependencies" issues

### DIFF
--- a/GeoFire.podspec
+++ b/GeoFire.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source_files = "GeoFire/**/*.{h,m}"
   s.documentation_url   = "https://geofire-ios.firebaseapp.com/docs/"
   s.ios.deployment_target = '7.0'
-  s.ios.dependency  'FirebaseCommunity/Database', '~> 0.0.1'
+  s.ios.dependency  'FirebaseCommunity/Database', '~> 0.0'
   s.framework = 'CoreLocation'
   s.requires_arc = true
 end

--- a/GeoFire.podspec
+++ b/GeoFire.podspec
@@ -1,15 +1,15 @@
 Pod::Spec.new do |s|
   s.name         = "GeoFire"
-  s.version      = "2.0.0"
+  s.version      = "2.0.1"
   s.summary      = "Realtime location queries with Firebase."
   s.homepage     = "https://github.com/firebase/geofire-objc"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = "Firebase"
-  s.source       = { :git => "https://github.com/firebase/geofire-objc.git", :tag => 'v2.0.0' }
+  s.source       = { :git => "https://github.com/firebase/geofire-objc.git", :tag => 'v2.0.1' }
   s.source_files = "GeoFire/**/*.{h,m}"
   s.documentation_url   = "https://geofire-ios.firebaseapp.com/docs/"
   s.ios.deployment_target = '7.0'
-  s.ios.dependency  'Firebase/Database', '~> 4.0'
+  s.ios.dependency  'FirebaseCommunity/Database', '~> 0.0.1'
   s.framework = 'CoreLocation'
   s.requires_arc = true
 end

--- a/GeoFire/Implementation/GFQuery.m
+++ b/GeoFire/Implementation/GFQuery.m
@@ -6,7 +6,8 @@
 //  Copyright (c) 2014 Firebase. All rights reserved.
 //
 
-#import <FirebaseDatabase/FirebaseDatabase.h>
+// TODO (mpmcdonald@): Change this back to Firebase once we can properly use the "regular" pod
+@import FirebaseCommunity.FirebaseDatabase;
 
 #import "GFQuery.h"
 #import "GFRegionQuery.h"

--- a/GeoFire/Implementation/GeoFire.m
+++ b/GeoFire/Implementation/GeoFire.m
@@ -6,7 +6,8 @@
 //  Copyright (c) 2014 Firebase. All rights reserved.
 //
 
-#import <FirebaseDatabase/FirebaseDatabase.h>
+// TODO (mpmcdonald@): Change this back to Firebase once we can properly use the "regular" pod
+@import FirebaseCommunity.FirebaseDatabase;
 
 #import "GeoFire.h"
 #import "GeoFire+Private.h"


### PR DESCRIPTION
Swapping Firebase pod (closed source) for FirebaseCommunity pod (open source), as it should end issues with "transitive dependencies on static binaries" that we're seeing (e.g. #48).

Note: due to duplicate symbol issues, if you want to use GeoFire in this way, you'll have to use the FirebaseCommunity pod for other dependencies (Auth, Storage, Messaging), and won't be able to use any other Firebase features. 

```ruby
  # your/project/path/Podfile
  target 'project' do
    pod 'FirebaseCommunity/Auth', '~> 0.0'
    pod 'FirebaseCommunity/Messaging', '~> 0.0'
    pod 'FirebaseCommunity/Storage', '~> 0.0'
    pod 'GeoFire', '~> 2.1'
  end
```

This should not cause a change in behavior (as the dependencies should be the same, one is source vs binary), hence the patch version bump. That said, given the potential to introduce duplicate symbol collisions, I'd be open to upgrading this to `3.0.0` to prevent people from automatically upgrading.

Once we can resolve the "transitive dependencies" issue in the Firebase pod (merging pods, shipping the pod as dylibs, etc.), we'll switch back to the Firebase pod and the above issue will go away.

