### PR TITLE
Add nullability annotations to public API

### DIFF
--- a/GeoFire/API/GFCircleQuery.h
+++ b/GeoFire/API/GFCircleQuery.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2016 Firebase. All rights reserved.
 //
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GFCircleQuery : GFQuery
 
 /**
@@ -21,3 +23,5 @@
 @property (atomic, readwrite) double radius;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/GeoFire/API/GFQuery.h
+++ b/GeoFire/API/GFQuery.h
@@ -29,6 +29,8 @@
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NSUInteger FirebaseHandle;
 
 @class GeoFire;
@@ -99,3 +101,5 @@ typedef void (^GFReadyBlock) (void);
 - (void)removeAllObservers;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/GeoFire/API/GFRegionQuery.h
+++ b/GeoFire/API/GFRegionQuery.h
@@ -9,6 +9,8 @@
 
 #import <MapKit/MapKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GFRegionQuery : GFQuery
 
 /**
@@ -18,3 +20,5 @@
 @property (atomic, readwrite) MKCoordinateRegion region;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/GeoFire/API/GeoFire.h
+++ b/GeoFire/API/GeoFire.h
@@ -36,8 +36,10 @@
 
 @class FIRDatabaseReference;
 
-typedef void (^GFCompletionBlock) (NSError *error);
-typedef void (^GFCallbackBlock) (CLLocation *location, NSError *error);
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^GFCompletionBlock) (NSError * _Nullable error);
+typedef void (^GFCallbackBlock) (CLLocation * _Nullable location, NSError * _Nullable error);
 
 /**
  * A GeoFire instance is used to store geo location data at a Firebase location.
@@ -70,7 +72,7 @@ typedef void (^GFCallbackBlock) (CLLocation *location, NSError *error);
  * @param location The location as a geographic coordinate
  * @param key The key for which this location is saved
  */
-- (void)setLocation:(CLLocation *)location
+- (void)setLocation:(nullable CLLocation *)location
              forKey:(NSString *)key;
 
 /**
@@ -80,9 +82,9 @@ typedef void (^GFCallbackBlock) (CLLocation *location, NSError *error);
  * @param key The key for which this location is saved
  * @param block The completion block that is called once the location was successfully updated on the server
  */
-- (void)setLocation:(CLLocation *)location
+- (void)setLocation:(nullable CLLocation *)location
              forKey:(NSString *)key
-withCompletionBlock:(GFCompletionBlock)block;
+withCompletionBlock:(nullable GFCompletionBlock)block;
 
 /**
  * Removes the location for a given key.
@@ -96,7 +98,7 @@ withCompletionBlock:(GFCompletionBlock)block;
  * @param key The key for which the location is removed
  * @param block The completion block that is called once the location was successfully updated on the server
  */
-- (void)removeKey:(NSString *)key withCompletionBlock:(GFCompletionBlock)block;
+- (void)removeKey:(NSString *)key withCompletionBlock:(nullable GFCompletionBlock)block;
 
 /**
  * Gets the current location for a key in GeoFire and calls the callback with the location or nil if there is no
@@ -128,3 +130,5 @@ withCompletionBlock:(GFCompletionBlock)block;
 - (GFRegionQuery *)queryWithRegion:(MKCoordinateRegion)region;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/GeoFire/API/GeoFire.h
+++ b/GeoFire/API/GeoFire.h
@@ -72,7 +72,7 @@ typedef void (^GFCallbackBlock) (CLLocation * _Nullable location, NSError * _Nul
  * @param location The location as a geographic coordinate
  * @param key The key for which this location is saved
  */
-- (void)setLocation:(nullable CLLocation *)location
+- (void)setLocation:(CLLocation *)location
              forKey:(NSString *)key;
 
 /**
@@ -82,7 +82,7 @@ typedef void (^GFCallbackBlock) (CLLocation * _Nullable location, NSError * _Nul
  * @param key The key for which this location is saved
  * @param block The completion block that is called once the location was successfully updated on the server
  */
-- (void)setLocation:(nullable CLLocation *)location
+- (void)setLocation:(CLLocation *)location
              forKey:(NSString *)key
 withCompletionBlock:(nullable GFCompletionBlock)block;
 


### PR DESCRIPTION
As mentioned in #105.

Nullability annotations were introduced in Xcode 6.3 (which included iOS 8.3). I'm not sure what the minimum supported Xcode version is in these parts, but if 6.3 is a reasonable minimum then we shouldn't need any `#define NS_ASSUME_NONNULL_BEGIN` etc. to pacify older versions of the dev tools. Let me know if I've guessed wrong here.