### PR TITLE
Update location with updateChildValues

### DIFF
--- a/GeoFire/Implementation/GeoFire.m
+++ b/GeoFire/Implementation/GeoFire.m
@@ -97,14 +97,16 @@ withCompletionBlock:(GFCompletionBlock)block
         value = nil;
         priority = nil;
     }
-    [[self firebaseRefForLocationKey:key] setValue:value
-                                       andPriority:priority
-                               withCompletionBlock:^(NSError *error, FIRDatabaseReference *ref) {
-        if (block != nil) {
-            dispatch_async(self.callbackQueue, ^{
-                block(error);
-            });
-        }
+    [[self firebaseRefForLocationKey:key] updateChildValues:value
+                                        withCompletionBlock:^(NSError *error, FIRDatabaseReference *ref) {
+        [[self firebaseRefForLocationKey:key] setPriority:priority
+                                      withCompletionBlock:^(NSError *error, FIRDatabaseReference *ref) {
+            if (block != nil) {
+                dispatch_async(self.callbackQueue, ^{
+                    block(error);
+                });
+            }
+      }];
     }];
 }
 

--- a/GeoFire/Implementation/GeoFire.m
+++ b/GeoFire/Implementation/GeoFire.m
@@ -86,27 +86,21 @@ withCompletionBlock:(GFCompletionBlock)block
                withBlock:(GFCompletionBlock)block
 {
     NSDictionary *value;
-    NSString *priority;
     if (location != nil) {
         NSNumber *lat = [NSNumber numberWithDouble:location.coordinate.latitude];
         NSNumber *lng = [NSNumber numberWithDouble:location.coordinate.longitude];
         NSString *geoHash = [GFGeoHash newWithLocation:location.coordinate].geoHashValue;
         value = @{ @"l": @[ lat, lng ], @"g": geoHash };
-        priority = geoHash;
     } else {
         value = nil;
-        priority = nil;
     }
     [[self firebaseRefForLocationKey:key] updateChildValues:value
                                         withCompletionBlock:^(NSError *error, FIRDatabaseReference *ref) {
-        [[self firebaseRefForLocationKey:key] setPriority:priority
-                                      withCompletionBlock:^(NSError *error, FIRDatabaseReference *ref) {
-            if (block != nil) {
-                dispatch_async(self.callbackQueue, ^{
-                    block(error);
-                });
-            }
-      }];
+        if (block != nil) {
+            dispatch_async(self.callbackQueue, ^{
+                block(error);
+            });
+        }
     }];
 }
 

--- a/GeoFireTests/GeoFireTest.m
+++ b/GeoFireTests/GeoFireTest.m
@@ -52,9 +52,6 @@
                };
 
             XCTAssertEqualObjects(snapshot.value, expected);
-            XCTAssertEqualObjects([snapshot childSnapshotForPath:@"loc1"].priority, @"7zzzzzzzzz");
-            XCTAssertEqualObjects([snapshot childSnapshotForPath:@"loc2"].priority, @"v0gs3y0zh7");
-            XCTAssertEqualObjects([snapshot childSnapshotForPath:@"loc3"].priority, @"1bpbpbpbpb");
             dispatch_semaphore_signal(barrier);
         }];
 


### PR DESCRIPTION
Use `updateChildValues` (and `setPriority`) in favor of `setValuesAndPriority` to avoid overwriting other child values.