### PR TITLE
Decrease minimum Firebase Database dependency requirement

### DIFF
--- a/GeoFire.podspec
+++ b/GeoFire.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.default_subspec = 'Database'
 
   s.subspec 'Database' do |db|
-    db.ios.dependency 'Firebase/Database', '~> 7.8.0'
+    db.ios.dependency 'Firebase/Database', '~> 7.0.0'
     db.ios.dependency 'GeoFire/Utils'
     db.public_header_files = "GeoFire/API/*"
     db.source_files = ["GeoFire/Implementation/*", "GeoFire/API/*"]


### PR DESCRIPTION
Decrease minimum Firebase Database dependency requirement to improve backwards compatibility

From 7.8.0 to 7.0.0