### PR TITLE
Add Package.swift

### DIFF
--- a/GeoFire/Implementation/GeoFire+Private.h
+++ b/GeoFire/Implementation/GeoFire+Private.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Firebase. All rights reserved.
 //
 
-#import <GeoFire/GeoFire.h>
+#import "GeoFire.h"
 #import <CoreLocation/CoreLocation.h>
 
 @interface GeoFire (Private)

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,56 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "GeoFire",
+    defaultLocalization: "en",
+    platforms: [.iOS(.v11), .macOS(.v10_12), .tvOS(.v10), .watchOS(.v7)],
+    products: [
+        .library(
+            name: "GeoFire",
+            targets: ["GeoFire"]
+        ),
+        .library(
+            name: "GeoFireUtils",
+            targets: ["GeoFireUtils"]
+        )
+    ],
+    dependencies: [
+        .package(name: "Firebase",
+                 url: "https://github.com/firebase/firebase-ios-sdk.git",
+                 .upToNextMajor(from: "7.0.0")),
+    ],
+    targets: [
+        .target(
+            name: "GeoFire",
+            dependencies: [
+                "GeoFireUtils",
+                .product(name: "FirebaseDatabase", package: "Firebase")
+            ],
+            path: "GeoFire",
+            exclude: [
+                "./Utils",
+            ],
+            publicHeadersPath: "./API"
+        ),
+        .testTarget(
+            name: "GeoFireTests",
+            dependencies: [
+                "GeoFire"
+            ],
+            path: "GeoFireTests",
+            exclude: [
+                "GeoFireTests-Info.plist",
+            ],
+            cSettings: [
+                .headerSearchPath("../GeoFire/API"),
+                .headerSearchPath("../GeoFire/Utils"),
+            ]
+        ),
+        .target(
+            name: "GeoFireUtils",
+            path: "GeoFire/Utils",
+            publicHeadersPath: "."
+        )
+    ]
+)


### PR DESCRIPTION
I think I can import GeoFire or GeoFireUtils through Swift Package Manager by this pull request.